### PR TITLE
Rebuild server logic for Raspberry Pi stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
 "description": "Raspberry Pi metrics webapp (no Python)",
 "main": "server.js",
 "type": "module",
-"scripts": {
-"start": "node server.js"
-},
+  "scripts": {
+    "start": "node server.js",
+    "test": "node test.js"
+  },
 "dependencies": {
 "express": "^4.19.2"
 }

--- a/server.js
+++ b/server.js
@@ -1,65 +1,109 @@
+import express from 'express';
+import os from 'os';
 import fs from 'fs';
-);
-const kb = k => Number(String(lines[k]).replace(/ kB$/, ''));
-const total = kb('MemTotal');
-// MemAvailable approximates free + reclaimable cache
-const available = kb('MemAvailable');
-const used = total - available;
-return { totalKB: total, usedKB: used, usedPct: total ? (used / total) * 100 : NaN };
+
+// Port for the HTTP server
+const PORT = process.env.PORT || 3000;
+
+// Paths for system metrics on a Raspberry Pi
+const paths = {
+  temp: '/sys/class/thermal/thermal_zone0/temp',
+  freq: '/sys/devices/system/cpu/cpufreq/policy0/cpuinfo_cur_freq',
+};
+
+const app = express();
+app.use(express.static('public'));
+
+// Helper to read a number from a file. Returns NaN on failure.
+function readNumber(p) {
+  try {
+    return Number(fs.readFileSync(p, 'utf8').trim());
+  } catch {
+    return NaN;
+  }
+}
+
+// Read memory information from /proc/meminfo
+function readMem() {
+  try {
+    const lines = Object.fromEntries(
+      fs
+        .readFileSync('/proc/meminfo', 'utf8')
+        .split('\n')
+        .filter(Boolean)
+        .map(l => l.split(/:\s+/))
+    );
+    const kb = k => Number(String(lines[k]).replace(/ kB$/, ''));
+    const total = kb('MemTotal');
+    // MemAvailable approximates free + reclaimable cache
+    const available = kb('MemAvailable');
+    const used = total - available;
+    return {
+      totalKB: total,
+      usedKB: used,
+      usedPct: total ? (used / total) * 100 : NaN,
+    };
+  } catch {
+    return { totalKB: 0, usedKB: 0, usedPct: NaN };
+  }
 }
 
 function readCpuTimes() {
-// Read aggregated CPU line from /proc/stat
-const first = fs.readFileSync('/proc/stat', 'utf8').split('\n').find(l => l.startsWith('cpu '));
-const parts = first.split(/\s+/).slice(1).map(Number);
-const [user, nice, system, idle, iowait, irq, softirq, steal] = parts;
-const idleAll = idle + iowait;
-const nonIdle = user + nice + system + irq + softirq + steal;
-const total = idleAll + nonIdle;
-return { idleAll, total };
+  // Read aggregated CPU line from /proc/stat
+  const first = fs
+    .readFileSync('/proc/stat', 'utf8')
+    .split('\n')
+    .find(l => l.startsWith('cpu '));
+  const parts = first.split(/\s+/).slice(1).map(Number);
+  const [user, nice, system, idle, iowait, irq, softirq, steal] = parts;
+  const idleAll = idle + iowait;
+  const nonIdle = user + nice + system + irq + softirq + steal;
+  const total = idleAll + nonIdle;
+  return { idleAll, total };
 }
 
 let prevTimes = readCpuTimes();
 let sample = {
-tempC: NaN,
-cpuFreqMHz: NaN,
-cpuUsagePct: NaN,
-ramUsedPct: NaN,
-ram: { totalKB: 0, usedKB: 0 },
-updatedAt: new Date().toISOString(),
-hostname: os.hostname(),
-uptimeSec: os.uptime()
+  tempC: NaN,
+  cpuFreqMHz: NaN,
+  cpuUsagePct: NaN,
+  ramUsedPct: NaN,
+  ram: { totalKB: 0, usedKB: 0 },
+  updatedAt: new Date().toISOString(),
+  hostname: os.hostname(),
+  uptimeSec: os.uptime(),
 };
 
 function refresh() {
-// Temperature (millidegC on Pi)
-const rawTemp = readNumber(paths.temp);
-const tempC = Number.isFinite(rawTemp) ? rawTemp / 1000 : NaN;
+  // Temperature (millidegC on Pi)
+  const rawTemp = readNumber(paths.temp);
+  const tempC = Number.isFinite(rawTemp) ? rawTemp / 1000 : NaN;
 
-// CPU frequency (kHz)
-const rawFreq = readNumber(paths.freq);
-const cpuFreqMHz = Number.isFinite(rawFreq) ? rawFreq / 1000 : NaN;
+  // CPU frequency (kHz)
+  const rawFreq = readNumber(paths.freq);
+  const cpuFreqMHz = Number.isFinite(rawFreq) ? rawFreq / 1000 : NaN;
 
-// CPU usage via delta of /proc/stat
-const nowTimes = readCpuTimes();
-const totald = nowTimes.total - prevTimes.total;
-const idled = nowTimes.idleAll - prevTimes.idleAll;
-const cpuUsagePct = totald > 0 ? ((totald - idled) / totald) * 100 : sample.cpuUsagePct;
-prevTimes = nowTimes;
+  // CPU usage via delta of /proc/stat
+  const nowTimes = readCpuTimes();
+  const totald = nowTimes.total - prevTimes.total;
+  const idled = nowTimes.idleAll - prevTimes.idleAll;
+  const cpuUsagePct =
+    totald > 0 ? ((totald - idled) / totald) * 100 : sample.cpuUsagePct;
+  prevTimes = nowTimes;
 
-// Memory
-const mem = readMem();
+  // Memory
+  const mem = readMem();
 
-sample = {
-tempC: Number(tempC.toFixed(1)),
-cpuFreqMHz: Number(cpuFreqMHz.toFixed(0)),
-cpuUsagePct: Number(cpuUsagePct.toFixed(1)),
-ramUsedPct: Number(mem.usedPct.toFixed(1)),
-ram: { totalKB: mem.totalKB, usedKB: mem.usedKB },
-updatedAt: new Date().toISOString(),
-hostname: os.hostname(),
-uptimeSec: os.uptime()
-};
+  sample = {
+    tempC: Number(tempC.toFixed(1)),
+    cpuFreqMHz: Number(cpuFreqMHz.toFixed(0)),
+    cpuUsagePct: Number(cpuUsagePct.toFixed(1)),
+    ramUsedPct: Number(mem.usedPct.toFixed(1)),
+    ram: { totalKB: mem.totalKB, usedKB: mem.usedKB },
+    updatedAt: new Date().toISOString(),
+    hostname: os.hostname(),
+    uptimeSec: os.uptime(),
+  };
 }
 
 // Refresh every 1s
@@ -67,10 +111,11 @@ setInterval(refresh, 1000);
 refresh();
 
 app.get('/api/stats', (_req, res) => {
-res.set('Cache-Control', 'no-store');
-res.json(sample);
+  res.set('Cache-Control', 'no-store');
+  res.json(sample);
 });
 
 app.listen(PORT, () => {
-console.log(`pi-stats listening on http://localhost:${PORT}`);
+  console.log(`pi-stats listening on http://localhost:${PORT}`);
 });
+

--- a/test.js
+++ b/test.js
@@ -1,0 +1,26 @@
+import assert from 'assert';
+import { spawn } from 'child_process';
+
+const PORT = 3100;
+
+const server = spawn('node', ['server.js'], {
+  env: { ...process.env, PORT: PORT },
+  stdio: 'inherit',
+});
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+try {
+  await sleep(500);
+  const res = await fetch(`http://localhost:${PORT}/api/stats`);
+  assert.equal(res.status, 200);
+  const json = await res.json();
+  assert.ok('tempC' in json);
+  console.log('API responded with tempC:', json.tempC);
+  console.log('Test passed');
+} finally {
+  server.kill();
+  await new Promise(resolve => server.on('exit', resolve));
+}


### PR DESCRIPTION
## Summary
- Implement complete Express server that reads Pi metrics and exposes `/api/stats`
- Add helper functions for reading system files and CPU/memory usage
- Ignore `node_modules` via `.gitignore`
- Add test script verifying `/api/stats` endpoint and wire up `npm test`

## Testing
- `npm test`
- `node server.js` & `curl -s http://localhost:3000/api/stats`


------
https://chatgpt.com/codex/tasks/task_e_68a4775bec3083228da0eddfc68bea88